### PR TITLE
Support generating const and fixed size arrays

### DIFF
--- a/binary_macros_impl/src/lib.rs
+++ b/binary_macros_impl/src/lib.rs
@@ -1,40 +1,35 @@
 extern crate data_encoding;
-extern crate proc_macro_hack;
-extern crate proc_macro;
 extern crate dotenv;
+extern crate proc_macro;
+extern crate proc_macro_hack;
 
-use std::str::FromStr;
-use std::io::Read;
-use proc_macro_hack::proc_macro_hack;
 use proc_macro::TokenStream;
+use proc_macro_hack::proc_macro_hack;
+use std::io::Read;
+use std::str::FromStr;
 
-fn helper(input: TokenStream, decoder: data_encoding::Encoding) -> TokenStream
-{
+fn helper(input: TokenStream, decoder: data_encoding::Encoding) -> TokenStream {
     let input = input.to_string();
     let input = input.trim_matches('"');
 
     let byte_vec = if input.starts_with("file:") {
-
         let mut file = std::fs::File::open(&input[5..]).expect("Error opening file");
         let mut contents = String::new();
-        file.read_to_string(&mut contents).expect("Error reading file");
-        decoder.decode(contents.trim().as_bytes()).expect("Parse error")
-
+        file.read_to_string(&mut contents)
+            .expect("Error reading file");
+        decoder
+            .decode(contents.trim().as_bytes())
+            .expect("Parse error")
     } else if input.starts_with("env:") {
-
         dotenv::dotenv().ok();
         let var = std::env::var(&input[4..]).expect("Error reading environment variable");
         decoder.decode(var.as_bytes()).expect("Parse error")
-
     } else {
-
         decoder.decode(input.as_bytes()).expect("Parse error")
-
     };
 
     TokenStream::from_str(&format!("{{static _BIN: [u8; {}] = {:?}; &_BIN}}", byte_vec.len(), byte_vec)).expect("Parse error")
 }
-
 
 #[proc_macro_hack]
 pub fn base16(input: TokenStream) -> TokenStream {
@@ -60,8 +55,6 @@ pub fn base64(input: TokenStream) -> TokenStream {
 pub fn base64url(input: TokenStream) -> TokenStream {
     helper(input, data_encoding::BASE64URL)
 }
-
-
 
 #[proc_macro_hack]
 pub fn base32hex_nopad(input: TokenStream) -> TokenStream {

--- a/binary_macros_impl/src/lib.rs
+++ b/binary_macros_impl/src/lib.rs
@@ -28,7 +28,7 @@ fn helper(input: TokenStream, decoder: data_encoding::Encoding) -> TokenStream {
         decoder.decode(input.as_bytes()).expect("Parse error")
     };
 
-    TokenStream::from_str(&format!("{{static _BIN: [u8; {}] = {:?}; &_BIN}}", byte_vec.len(), byte_vec)).expect("Parse error")
+    TokenStream::from_str(&format!("{:?}", byte_vec)).expect("Parse error")
 }
 
 #[proc_macro_hack]


### PR DESCRIPTION
Currently we can't do this because const variables cannot refer to statics (inside the macro expansion):
```rust
const A: &[u8] = &base16!("55aa");
const B: [u8; 2] = base16!("55aa");
```
This PR, changes that, so after the macro expansion it looks like a raw byte array. This allows us to create const and static slices as well as fixed size arrays.

Creates a slight change in API, now we are expanding into a raw fixed size array, so to get a slice it requires an extra `&`:
Before: 
```rust
let res: &[u8] = base16!("55aa");
```
After: 
```rust
let res: &[u8] = &base16!("55aa");
```

I personally think that expanding the use case of this library from just static slices to const and static slices and fixed size arrays is worth this API change. But of course I would like to also hear your opinion.